### PR TITLE
Workaround for crash, missing getTimeZone()

### DIFF
--- a/ailib/src/main/java/ai/api/android/AIDataService.java
+++ b/ailib/src/main/java/ai/api/android/AIDataService.java
@@ -21,12 +21,15 @@ package ai.api.android;
  *
  ***********************************************************************************************************************/
 
+import java.util.TimeZone;
+
 import android.content.Context;
 import android.support.annotation.NonNull;
 
 import com.google.gson.Gson;
 
 import ai.api.AIServiceContext;
+
 
 /**
  * Do simple requests to the AI Service
@@ -62,5 +65,7 @@ public class AIDataService extends ai.api.AIDataService {
         public String getSessionId() {
             return sessionId;
         }
+
+        public TimeZone getTimeZone() { return null; }
     }
 }


### PR DESCRIPTION
This is a naive workaround because AIServiceContext requires getTimeZone(),
but AIAndroidServiceContext does not provide it, causing a crash.